### PR TITLE
Add complete boolean for rides

### DIFF
--- a/lib/prison_rideshare_web/controllers/ride_controller.ex
+++ b/lib/prison_rideshare_web/controllers/ride_controller.ex
@@ -32,7 +32,7 @@ defmodule PrisonRideshareWeb.RideController do
           r in Ride,
           where:
             r.enabled and is_nil(r.combined_with_ride_id) and
-              is_nil(r.distance) and not(r.car_expenses > 0) and
+              not r.complete and
               not is_nil(r.driver_id),
           preload: [:institution, :driver]
         )

--- a/lib/prison_rideshare_web/models/ride.ex
+++ b/lib/prison_rideshare_web/models/ride.ex
@@ -12,6 +12,7 @@ defmodule PrisonRideshareWeb.Ride do
     field(:passengers, :integer, default: 1)
     field(:request_notes, :string)
     field(:enabled, :boolean, default: true)
+    field(:complete, :boolean, default: false)
     field(:cancellation_reason, :string)
 
     field(:distance, :integer)
@@ -59,6 +60,7 @@ defmodule PrisonRideshareWeb.Ride do
       :passengers,
       :request_notes,
       :enabled,
+      :complete,
       :cancellation_reason,
       :combined_with_ride_id,
       :institution_id,

--- a/lib/prison_rideshare_web/models/ride.ex
+++ b/lib/prison_rideshare_web/models/ride.ex
@@ -117,6 +117,7 @@ defmodule PrisonRideshareWeb.Ride do
     struct
     |> cast(params, [:distance, :car_expenses, :food_expenses, :report_notes, :donation])
     |> validate_required([:distance, :food_expenses])
+    |> put_change(:complete, true)
   end
 
   def report_changeset(struct, params) do
@@ -124,6 +125,7 @@ defmodule PrisonRideshareWeb.Ride do
     |> cast(params, [:distance, :food_expenses, :report_notes, :donation])
     |> validate_required([:distance, :food_expenses])
     |> calculate_car_expenses(struct)
+    |> put_change(:complete, true)
   end
 
   defp calculate_car_expenses(%{valid?: false} = changeset, _), do: changeset

--- a/lib/prison_rideshare_web/views/ride_view.ex
+++ b/lib/prison_rideshare_web/views/ride_view.ex
@@ -14,6 +14,7 @@ defmodule PrisonRideshareWeb.RideView do
     :passengers,
     :request_notes,
     :enabled,
+    :complete,
     :cancellation_reason,
     :distance,
     :rate,

--- a/priv/repo/migrations/20190507024525_add_rides_complete.exs
+++ b/priv/repo/migrations/20190507024525_add_rides_complete.exs
@@ -1,0 +1,9 @@
+defmodule PrisonRideshare.Repo.Migrations.AddRidesComplete do
+  use Ecto.Migration
+
+  def change do
+    alter table(:rides) do
+      add(:complete, :boolean, default: false)
+    end
+  end
+end

--- a/priv/repo/migrations/20190507024525_add_rides_complete.exs
+++ b/priv/repo/migrations/20190507024525_add_rides_complete.exs
@@ -1,9 +1,19 @@
 defmodule PrisonRideshare.Repo.Migrations.AddRidesComplete do
   use Ecto.Migration
 
-  def change do
+  def up do
     alter table(:rides) do
       add(:complete, :boolean, default: false)
+    end
+
+    execute("""
+      update rides set complete = true where distance > 0 or car_expenses > 0
+    """)
+  end
+
+  def down do
+    alter table(:rides) do
+      remove(:complete)
     end
   end
 end

--- a/test/controllers/ride_controller_test.exs
+++ b/test/controllers/ride_controller_test.exs
@@ -11,6 +11,7 @@ defmodule PrisonRideshareWeb.RideControllerTest do
     address: "some content",
     contact: "some content",
     distance: 120,
+    complete: true,
     end: %{day: 17, month: 4, year: 2010, hour: 14, min: 0, sec: 0},
     food_expenses: 42,
     name: "some content",
@@ -129,6 +130,7 @@ defmodule PrisonRideshareWeb.RideControllerTest do
                  "car-expenses" => ride.car_expenses,
                  "distance" => ride.distance,
                  "enabled" => ride.enabled,
+                 "complete" => ride.complete,
                  "food-expenses" => ride.food_expenses,
                  "request-notes" => ride.request_notes,
                  "report-notes" => ride.report_notes,
@@ -334,7 +336,7 @@ defmodule PrisonRideshareWeb.RideControllerTest do
   end
 
   test "shows chosen resource", %{conn: conn} do
-    ride = Repo.insert!(%Ride{rate: 35, first_time: true, medium: "phone"})
+    ride = Repo.insert!(%Ride{rate: 35, first_time: true, medium: "phone", complete: true})
     conn = get(conn, ride_path(conn, :show, ride))
     data = json_response(conn, 200)["data"]
     assert data["id"] == "#{ride.id}"
@@ -350,6 +352,7 @@ defmodule PrisonRideshareWeb.RideControllerTest do
     assert data["attributes"]["passengers"] == ride.passengers
     assert data["attributes"]["request_notes"] == ride.request_notes
     assert data["attributes"]["distance"] == ride.distance
+    assert data["attributes"]["complete"]
     assert data["attributes"]["rate"] == ride.rate
     assert data["attributes"]["food-expenses"] == ride.food_expenses
     assert data["attributes"]["car-expenses"] == ride.car_expenses

--- a/test/controllers/unauth_ride_controller_test.exs
+++ b/test/controllers/unauth_ride_controller_test.exs
@@ -185,6 +185,7 @@ defmodule PrisonRideshare.UnauthRideControllerTest do
     assert ride.report_notes == "Some report notes"
     assert ride.request_notes == "The original request notes"
     assert ride.donation
+    assert ride.complete
     refute ride.overridable
 
     assert_delivered_email(PrisonRideshare.Email.report(ride))
@@ -245,6 +246,7 @@ defmodule PrisonRideshare.UnauthRideControllerTest do
 
     assert ride.distance == 77
     assert ride.car_expenses == ~M[100]
+    assert ride.complete
   end
 
   test "does not update chosen resource and renders errors when data is invalid", %{conn: conn} do

--- a/test/controllers/unauth_ride_controller_test.exs
+++ b/test/controllers/unauth_ride_controller_test.exs
@@ -50,7 +50,7 @@ defmodule PrisonRideshare.UnauthRideControllerTest do
 
     Repo.insert!(%Ride{
       driver: driver,
-      car_expenses: ~M[77]
+      complete: true
     })
 
     Repo.insert!(%Ride{


### PR DESCRIPTION
Since drivers are being told they can enter zero distances for van trips,
the synthetic flag where distance is greater than zero is inadequate.

This closes backspace/prison-rideshare-ui#99.